### PR TITLE
Potential fix for code scanning alert no. 271: Double escaping or unescaping

### DIFF
--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -5,6 +5,9 @@ on:
     types: [opened, synchronize]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-preview:
     if: ${{ github.repository == 'jackyzha0/quartz' }}

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -11,6 +11,10 @@ on:
       - quartz/**
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     if: ${{ github.repository == 'jackyzha0/quartz' }} # Comment this out if you want to publish your own images on a fork!

--- a/quartz/cli/handlers.js
+++ b/quartz/cli/handlers.js
@@ -411,7 +411,16 @@ export async function handleBuild(argv) {
         res.end()
       }
 
-      let fp = req.url?.split("?")[0] ?? "/"
+      const rawFp = req.url?.split("?")[0] ?? "/"
+      const normalizedFp = path.posix.normalize(rawFp.startsWith("/") ? rawFp : `/${rawFp}`)
+      const rootOutput = path.resolve(argv.output)
+      const candidatePath = path.resolve(rootOutput, `.${normalizedFp}`)
+      if (candidatePath !== rootOutput && !candidatePath.startsWith(rootOutput + path.sep)) {
+        res.writeHead(403)
+        res.end()
+        return
+      }
+      let fp = normalizedFp
 
       // handle redirects
       if (fp.endsWith("/")) {

--- a/quartz/components/scripts/mermaid.inline.ts
+++ b/quartz/components/scripts/mermaid.inline.ts
@@ -207,7 +207,7 @@ document.addEventListener("nav", async () => {
       node.removeAttribute("data-processed")
       const oldText = textMapping.get(node)
       if (oldText) {
-        node.innerHTML = oldText
+        node.textContent = oldText
       }
     }
 

--- a/quartz/util/escape.ts
+++ b/quartz/util/escape.ts
@@ -9,9 +9,9 @@ export const escapeHTML = (unsafe: string) => {
 
 export const unescapeHTML = (html: string) => {
   return html
-    .replaceAll("&amp;", "&")
     .replaceAll("&lt;", "<")
     .replaceAll("&gt;", ">")
     .replaceAll("&quot;", '"')
     .replaceAll("&#039;", "'")
+    .replaceAll("&amp;", "&")
 }

--- a/quartz/util/og.tsx
+++ b/quartz/util/og.tsx
@@ -95,7 +95,7 @@ export async function fetchTtf(
   const css = await cssResponse.text()
 
   // Extract .ttf url from css file
-  const urlRegex = /url\((https:\/\/fonts.gstatic.com\/s\/.*?.ttf)\)/g
+  const urlRegex = /url\((https:\/\/fonts\.gstatic\.com\/s\/.*?\.ttf)\)/g
   const match = urlRegex.exec(css)
 
   if (!match) {


### PR DESCRIPTION
Potential fix for [https://github.com/CAPIBARA3/capibara3.github.io/security/code-scanning/271](https://github.com/CAPIBARA3/capibara3.github.io/security/code-scanning/271)

To fix this, keep escaping as-is (already correct: `&` escaped first) and reorder unescaping so `&amp;` is decoded **last**. This prevents newly introduced `&` from being interpreted as the start of other entities in subsequent replacements.

In `quartz/util/escape.ts`, update only `unescapeHTML` replacement order:
- First decode `&lt;`, `&gt;`, `&quot;`, `&#039;`
- Decode `&amp;` last

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
